### PR TITLE
Fix broken link - http://ephemeralpg.org/ is no more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# asdf-ephemeral-pg ![Build](https://github.com/smashedtoatoms/asdf-ephemeral-postgres/workflows/Build/badge.svg?branch=master)
+# asdf-ephemeral-postgres ![Build](https://github.com/smashedtoatoms/asdf-ephemeral-postgres/workflows/Build/badge.svg?branch=master)
 
-[Ephemeral PostgreSQL](http://ephemeralpg.org/) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+[Ephemeral PostgreSQL](https://github.com/eradman/ephemeralpg) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 
 ## Dependencies
 1. You will need make and postgres installed.

--- a/bin/install
+++ b/bin/install
@@ -69,7 +69,7 @@ get_download_file_path() {
 get_download_url() {
   local install_type=$1
   local version=$2
-  echo "http://ephemeralpg.org/code/ephemeralpg-${version}.tar.gz"
+  echo "https://eradman.com/ephemeralpg/code/ephemeralpg-${version}.tar.gz"
 }
 
 

--- a/bin/list-all
+++ b/bin/list-all
@@ -23,6 +23,7 @@ versions_list=(
   2.9
   3.0
   3.1
+  3.2
 )
 
 versions=""


### PR DESCRIPTION
The web site http://ephemeralpg.org/ is no more active. https://github.com/eradman/ephemeralpg is the new home.

This PR fixes README.md link, ~~but doesn't fix~~ and the plugin.

```bash
$ asdf install ethemeral-postgres latest
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: ephemeralpg.org
tar (child): /tmp/tmp.e3RsIK6G5Y/ephemeral-postgres-3.1.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```